### PR TITLE
Update React Headers

### DIFF
--- a/ios/RCTToast/Toast.m
+++ b/ios/RCTToast/Toast.m
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
-#import "RCTLog.h"
-#import "RCTBridgeModule.h"
+#import "React/RCTLog.h"
+#import "React/RCTBridgeModule.h"
 #import "Toast+UIView.h"
 
 


### PR DESCRIPTION
iOS headers have been moved in react 40.0

https://github.com/facebook/react-native/releases/tag/v0.40.0

Ciaran