### PR TITLE
Adds forward compatibility with RN > 0.40 and

### DIFF
--- a/ios/RCTToast/Toast.m
+++ b/ios/RCTToast/Toast.m
@@ -1,8 +1,13 @@
 #import <UIKit/UIKit.h>
-#import <React/RCTLog.h>
-#import <React/RCTBridgeModule.h>
 #import "Toast+UIView.h"
 
+#if __has_include(<React/RCTAssert.h>)
+#import <React/RCTLog.h>
+#import <React/RCTBridgeModule.h>
+#else // back compatibility for RN version < 0.40
+#import "RCTLog.h"
+#import "RCTBridgeModule.h"
+#endif
 
 @interface Toast : NSObject <RCTBridgeModule>
 @end
@@ -10,7 +15,6 @@
 @implementation Toast
 
 RCT_EXPORT_MODULE(Toast)
-
 
 RCT_EXPORT_METHOD(show:(NSDictionary *)options) {
     NSString *message  = [options objectForKey:@"message"];


### PR DESCRIPTION
Keeps backwards compatibility.
This prevents linker errors on the compiler with React Native versions above 0.40.
Also prevents unlinked NativeModules causing the toast not to appear.
 
Fixes #18 and #1
For us fixed #12