### PR TITLE
Fix for 0.47 Breaking Change with createJSModules Override

### DIFF
--- a/android/src/main/java/com/remobile/toast/RCTToastPackage.java
+++ b/android/src/main/java/com/remobile/toast/RCTToastPackage.java
@@ -18,7 +18,8 @@ public class RCTToastPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // DEPRECATED 0.47
+    //@Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fix for a breaking change made in react native 0.47 "Remove unused createJSModules calls"