### PR TITLE
Compatibility fix for RN 0.47: remove createJSModules override

### DIFF
--- a/android/src/main/java/com/remobile/toast/RCTToastPackage.java
+++ b/android/src/main/java/com/remobile/toast/RCTToastPackage.java
@@ -18,7 +18,6 @@ public class RCTToastPackage implements ReactPackage {
         );
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fixes a breaking change introduced in RN 0.47
https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8