### PR TITLE
Update Toast.java - Android Crash "Native module Toast tried to override Toast for module name RCTToast"

### DIFF
--- a/android/src/main/java/com/remobile/toast/Toast.java
+++ b/android/src/main/java/com/remobile/toast/Toast.java
@@ -57,6 +57,12 @@ public class Toast extends ReactContextBaseJavaModule implements LifecycleEventL
         });
     }
 
+    
+    @Override
+    public boolean canOverrideExistingModule() {
+      return true;
+    }
+    
     @ReactMethod
     public void hide() throws Exception {
         if (mostRecentToast != null) {


### PR DESCRIPTION
Fix the issue on Android where it complains about not overriding existing module.